### PR TITLE
Correct version number dist-info directory

### DIFF
--- a/recipe/0001-correct-version-number.patch
+++ b/recipe/0001-correct-version-number.patch
@@ -1,0 +1,25 @@
+From 2b0c4c8c61e1ce1af69b6682e16479c02f61a88f Mon Sep 17 00:00:00 2001
+From: Jonathan Helmus <jjhelmus@gmail.com>
+Date: Wed, 22 Aug 2018 16:10:23 -0500
+Subject: [PATCH] correct version number
+
+---
+ setup.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/setup.py b/setup.py
+index 2f7dac9..a728fdb 100644
+--- a/setup.py
++++ b/setup.py
+@@ -21,7 +21,7 @@ and is distributed under the MIT license.
+ '''
+ 
+ setup(name='Keras_Preprocessing',
+-      version='1.0.1',
++      version='1.0.2',
+       description='Easy data preprocessing and data augmentation '
+                   'for deep learning models',
+       long_description=long_description,
+-- 
+2.7.4
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,3 +49,4 @@ about:
 extra:
   recipe-maintainers:
     - CurtLH
+    - jjhelmus

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,10 +9,13 @@ package:
 source:
   url: https://github.com/keras-team/{{ name }}/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - 0001-correct-version-number.patch
+
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: python -m pip install --no-deps --ignore-installed .
 
 requirements:


### PR DESCRIPTION
The version number in the setup.py file in the GitHub archive for the 1.0.2 tag
is incorrectly recorded as 1.0.1.  This leads disagreement in the package 
version (1.0.2) and the version in the dist-info directory, the later of which
is used by pip to determine the version.

This patches the setup.py file to record the correct version.